### PR TITLE
補充重要安裝說明

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,11 @@ sudo apt-get install virtualbox
 sudo apt-get install vagrant virtualbox-dkms
 ```
 
+### 將 keanux-vagrant 環境 clone 至本機（包含 submodule ）
+```
+git clone git@github.com:Keanux/keanux-vagrant.git --recursive
+```
+
 ## 開始使用
 
 在這之前，你可以在 tools/vagrant.sh 中設定 mysql 的 root 密碼(MYSQL_PASSWORD)，預設為 "password"


### PR DESCRIPTION
增加將keanux-vagrant clone至步驟至說明中。
原本此處沒寫清楚，clone如沒加參數，keanux-vagrant的資料夾會是空的，
後續的啟動都會有錯誤！
